### PR TITLE
Enable GitHub merge queue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Clippy
+name: Lint
 
 on:
   push:
@@ -11,12 +11,9 @@ env:
 
 jobs:
   clippy:
-
     runs-on: ubuntu-latest
-
     permissions:
       security-events: write
-
     steps:
     - uses: actions/checkout@v3
     - name: Install SARIF tools
@@ -33,3 +30,15 @@ jobs:
       with:
         sarif_file: clippy-results.sarif
         wait-for-processing: true
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run rustfmt
+      run: cargo fmt --all --check
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check documentation
+      run: RUSTDOCFLAGS="-D warnings" cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,15 +5,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    types: [ checks_requested ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Build


### PR DESCRIPTION
Enable GitHub merge queue and add a `rustfmt` and `cargo doc` action checks.