### PR TITLE
Remove scheduled run of lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '20 5 25 * *'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If the repository is inactive for a long time, this `lint` action would become suspended/inactive. This means that the action will not even run if there was a new pull request after this.

I didn't find a way to still trigger the action from a pull request if it became inactive because of the schedule.