### PR TITLE
Mark `DataType` enum as non-exhaustive

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ More examples with common use cases can be found
 ## Feature flags
 
 - `rayon`: Implement [`rayon`](https://crates.io/crates/rayon)'s 
-`IntoParallelIterator` for `FileView`. This feature makes parallel analysis of
-MIDAS events very easy with the `FileView::par_iter` and
-`FileView::into_par_iter` methods.
+  `IntoParallelIterator` for `FileView`. This feature makes parallel analysis of
+  MIDAS events very easy with the `FileView::par_iter` and
+  `FileView::into_par_iter` methods.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1445,7 +1445,6 @@ mod tests {
     fn file_view_invalid_eor_le() {
         let mut file = file_le(0, 0, b"", &[], 0, b"");
         file[16..18].copy_from_slice(&[0, 0]);
-        dbg!(&file);
         assert!(FileView::try_from_bytes(&file).is_err());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ impl std::error::Error for ParseError {
 
 /// Possible data types stored inside a data bank.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DataType {
     /// Unsigned byte.
     U8,


### PR DESCRIPTION
Fix issue #29 

In the future, MIDAS data banks might add different data type tags (could be anything random like e.g. `i24`). We don't want to need to release a new breaking change for whatever new variant is added here.